### PR TITLE
update H3LIS331 & S25FL512S Library

### DIFF
--- a/SPIflash_S25FL512S/src/S25FL512S.h
+++ b/SPIflash_S25FL512S/src/S25FL512S.h
@@ -1,3 +1,4 @@
+// version 1.2.0
 #pragma once
 
 #ifndef SPIFlash_H
@@ -23,7 +24,22 @@ using namespace arduino::esp32::spi::dma;
 #define CMD_RDSR 0x05
 
 #define ADDRESS_LENGTH 32
-#define PAGE_LENGTH 512 // You can change this number to an aliquot part of 512.
+// #define PAGE_LENGTH 512 // You can change this number to an aliquot part of 512.
+#define PAGE_LENGTH 256
+
+// SPI Flashの最大のアドレス (1回で1/2ページ書き込んでいる点に注意)
+// (512 * 1024 * 1024 / 8 / 256 ページ * 256) * 2 = 524288 * 256
+uint32_t SPI_FLASH_MAX_ADDRESS = 0x8000000;
+
+// SPIFlashLatestAddressは書き込むアドレス。初期値は0x000
+// 0x000はreboot対策のどこまでSPI Flashに書き込んだかを記録するページ
+// setup()で初期値でも0x100にしている
+uint32_t SPIFlashLatestAddress = 0x000;
+
+uint8_t count = 1;
+uint8_t flashRead[256];
+uint8_t flashRead1[256];
+uint8_t flashRead2[256];
 
 class Flash
 {
@@ -33,6 +49,8 @@ class Flash
 
 public:
     void begin(SPICREATE::SPICreate *targetSPI, int cs, uint32_t freq = 8000000);
+    uint32_t checkAddress(uint32_t FlashAddress);
+    uint32_t setFlashAddress();
     void erase();
     void write(uint32_t addr, uint8_t *tx);
     void read(uint32_t addr, uint8_t *rx);
@@ -69,6 +87,84 @@ void Flash::begin(SPICREATE::SPICreate *targetSPI, int cs, uint32_t freq)
     delay(100);
     return;
 }
+
+uint32_t Flash::checkAddress(uint32_t FlashAddress)
+{
+    count++;
+    // if (count >= 20) // これ以上行くとページの途中を読むことになる。
+    // {
+    //   Serial.printf("FlashAddress: %u\n", FlashAddress);
+    //   return FlashAddress;
+    // }
+    if ((FlashAddress + 0x100) >= SPI_FLASH_MAX_ADDRESS)
+    {
+        // Serial.printf("FlashAddress: %u\n", FlashAddress);
+        // Serial.printf("count: %u\n", count);
+        return SPI_FLASH_MAX_ADDRESS;
+    }
+    Flash::read(FlashAddress, flashRead1);
+    delay(1);
+    Flash::read(FlashAddress + 0x100, flashRead2);
+    delay(1);
+    if (flashRead1[0] != 0xFF)
+    {
+        if (flashRead2[0] != 0xFF)
+        {
+            // ++
+            // Serial.println("---");
+            // uint32_t a = FlashAddress + SPI_FLASH_MAX_ADDRESS / pow(2, count);
+            // Serial.printf("FlashAddress: %u\n", a);
+            // Serial.printf("count: %u\n", count);
+            return checkAddress(FlashAddress + SPI_FLASH_MAX_ADDRESS / pow(2, count));
+        }
+        else
+        {
+            // Serial.printf("FlashAddress: %u\n", FlashAddress);
+            return FlashAddress;
+        }
+    }
+    else
+    {
+        if (flashRead2[0] != 0xFF)
+        {
+            // Serial.printf("FlashAddress: %u\n", FlashAddress);
+            // Serial.println("error");
+            return 0;
+        }
+        else
+        {
+            // --
+            // Serial.printf("FlashAddress: %u\n", FlashAddress);
+            return checkAddress(FlashAddress - SPI_FLASH_MAX_ADDRESS / pow(2, count));
+        }
+    }
+}
+
+uint32_t Flash::setFlashAddress()
+{
+    while (SPIFlashLatestAddress <= 0x1000)
+    {
+        Flash::read(SPIFlashLatestAddress, flashRead);
+        SPIFlashLatestAddress += 0x100;
+        // Serial.printf("SPIFlashLatestAddress: %u\n", SPIFlashLatestAddress);
+        // Serial.print(flashRead[0]);
+        delay(1);
+        // Serial.print("\n");
+        if (flashRead[0] == 0xFF)
+        {
+            // Serial.println("255");
+            return SPIFlashLatestAddress;
+        }
+        if (SPIFlashLatestAddress >= SPI_FLASH_MAX_ADDRESS)
+        {
+            // Serial.printf("SPIFlashLatestAddress: %u\n", SPIFlashLatestAddress);
+            return SPIFlashLatestAddress;
+        }
+    }
+    SPIFlashLatestAddress = checkAddress(SPI_FLASH_MAX_ADDRESS / 2);
+    return SPIFlashLatestAddress;
+}
+
 void Flash::erase()
 {
     Serial.println("start erase");

--- a/SPIflash_S25FL512S/src/main.cpp
+++ b/SPIflash_S25FL512S/src/main.cpp
@@ -19,6 +19,7 @@ void setup()
   Serial.begin(115200);
   SPIC1.begin(VSPI, SCK1, MISO1, MOSI1);
   flash1.begin(&SPIC1, flashCS, 100000);
+  uint32_t address = flash1.setFlashAddress();
   // put your setup code here, to run once:
   Serial.println("Launched");
 }


### PR DESCRIPTION
H3LIS331の後方互換性がなくなっています。
`H3LIS331::Get()`
もう一世代前のものと同じになるようにしています。